### PR TITLE
Add labeler on GitHub Actions

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,24 @@
+type/feature:
+    - head-branch:
+      - "feature/*"
+type/bug:
+  - head-branch:
+    - "fix/*"
+    - "hotfix/*"
+Documentation:
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
+apps:
+  - changed-files:
+    - any-glob-to-any-file: 'apps/**'
+packages:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/**'
+CI/CD:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/**'
+    - any-glob-to-any-file: '.github/actions/**'
+    - any-glob-to-any-file: '.github/labeler.yaml'
+release:
+ - base-branch: 'main'
+ 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: ".github/labeler.yaml"
+          sync-labels: true


### PR DESCRIPTION
This pull request includes changes to automate the labeling of pull requests based on specific criteria. The most important changes include adding configuration for the labeler and setting up a GitHub Actions workflow to apply the labels.

Labeling configuration:

* [`.github/labeler.yaml`](diffhunk://#diff-9c4d50f5955021b6a0cb61c03c5f350a86f62d1ca3781153620eea9f80539803R1-R24): Added rules to label pull requests based on branch names and changed files. This includes labels for features, bugs, documentation, apps, packages, CI/CD, and releases.

GitHub Actions workflow:

* [`.github/workflows/labeler.yaml`](diffhunk://#diff-5035e5e1050fac468f91ee7ad13264a79ef3e6e08a52af2110801aced423737dR1-R18): Created a workflow to automatically label pull requests using the defined rules in `labeler.yaml`. The workflow triggers on pull request events and uses the `actions/labeler` action.