### PR TITLE
Fix: warning

### DIFF
--- a/packages/features/counter/lib/counter_root_navigation.dart
+++ b/packages/features/counter/lib/counter_root_navigation.dart
@@ -32,7 +32,7 @@ class CounterRootNavigation extends StatelessWidget {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
+                MaterialPageRoute<StatelessCounterPage>(
                   builder: (context) => const StatelessCounterPage(),
                 ),
               );


### PR DESCRIPTION
This pull request includes a small change to the `packages/features/counter/lib/counter_root_navigation.dart` file. The change specifies the type parameter for `MaterialPageRoute` to be `StatelessCounterPage`.

* [`packages/features/counter/lib/counter_root_navigation.dart`](diffhunk://#diff-bd10c6af73928eb98f7a2087cf5c01e4d1cae703d30bcfef0568a3b091e4d364L35-R35): Changed `MaterialPageRoute` to `MaterialPageRoute<StatelessCounterPage>` to specify the type parameter.