### PR TITLE
Fix: warning

### DIFF
--- a/packages/repositories/lib/entities/feed_enclosure.dart
+++ b/packages/repositories/lib/entities/feed_enclosure.dart
@@ -9,8 +9,8 @@ class FeedEnclosure {
 
   factory FeedEnclosure.fromJson(Map<String, dynamic> json) {
     return FeedEnclosure(
-      link: json['link'],
-      type: json['type'],
+      link: json['link'] as String,
+      type: json['type'] as String,
     );
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `FeedEnclosure` class in the `packages/repositories/lib/entities/feed_enclosure.dart` file. The change involves casting the `link` and `type` fields to `String` when creating a `FeedEnclosure` instance from JSON.